### PR TITLE
add a internet needed message in login/register view

### DIFF
--- a/app/components/app-settings/AppSettingsAccountAddView.vue
+++ b/app/components/app-settings/AppSettingsAccountAddView.vue
@@ -2,6 +2,10 @@
     <Page>
         <PlatformHeader :title="_L('appSettings.account.addAccount')" :canNavigateSettings="false" :canCancel="true" />
         <SettingsLayout class="m-x-10">
+            <StackLayout v-if="!isOnline" orientation="horizontal" class="banner-internet">
+                <Image width="20" class="banner-internet-img" src="~/images/Icon_Warning_error.png"></Image>
+                <Label :text="_L('mustBeConnected')" />
+            </StackLayout>
             <GridLayout rows="*,auto">
                 <LoginForm row="0" v-if="login" :allowContinueOffline="false" :busy="busy" @saved="onLoginSaved" />
 
@@ -26,6 +30,7 @@ import SharedComponents from "@/components/shared";
 import { Dialogs } from "@nativescript/core";
 import { debug } from "@/lib";
 import { fullRoutes } from "~/routes";
+import axios from "axios";
 
 export default Vue.extend({
     name: "AppSettingsAccountAddView",
@@ -37,11 +42,16 @@ export default Vue.extend({
     data(): {
         login: boolean;
         busy: boolean;
+        isOnline: boolean;
     } {
         return {
             login: true,
             busy: false,
+            isOnline: true,
         };
+    },
+    mounted() {
+        this.checkIfOnline();
     },
     methods: {
         toggle(): void {
@@ -70,6 +80,10 @@ export default Vue.extend({
                 // this.busy = false;
             }
         },
+        async checkIfOnline() {
+            const response = await axios.request({ url: "https://google.com", timeout: 3000 });
+            this.isOnline = response.status === 200;
+        },
     },
 });
 </script>
@@ -87,5 +101,15 @@ export default Vue.extend({
     font-size: 14;
     margin-bottom: 10;
     font-weight: bold;
+}
+
+.banner-internet {
+    background: $fk-gray-lightest;
+    padding: 10 15;
+    font-size: 14;
+
+    &-img {
+        margin-right: 12;
+    }
 }
 </style>

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1003,5 +1003,6 @@
         }
     },
   "registerTncLabel": "By creating an account you agree to our",
-  "registerTncLabelLink": "Terms of Use."
+  "registerTncLabelLink": "Terms of Use.",
+  "mustBeConnected": "You must be connected to the internet"
 }


### PR DESCRIPTION
@jlewallen Hey,  I am not 100% satisfied with how I handled this task.

Checking for a live internet connection on mounted only means there won't be any message displayed if:
 - user navigates to this screen and loses connection before trying to login.
 - user navigates to this screen, but does not try to login, instead browses the app some more and then comes back here, mounted() is not called again. therefore if he lost internet connection while browsing the app, there won't be any message displayed.
 
Should I handle those cases? If yes, I suppose I can call this function with an interval of 30s.
 
 Let me know what you think,


