### PR TITLE
fix: done navigation after calibration

### DIFF
--- a/app/routes/index.ts
+++ b/app/routes/index.ts
@@ -55,16 +55,10 @@ export async function navigateBackToBookmark(vue: Vue, frameId: string | undefin
     for (const a of frame.backStack) {
         const entryProps = a.entry as { props?: { bookmark?: boolean } };
         debug.log(`navigate-back-to-bookmark: ${frame.id} ${JSON.stringify(entryProps)}`);
+        void vue.$navigateBack({ frame: frameToNav }, a);
+        return true;
     }
-
-    for (const a of frame.backStack) {
-        const entryProps = a.entry as { props?: { bookmark?: boolean } };
-        if (entryProps.props?.bookmark === true) {
-            void vue.$navigateBack({ frame: frameToNav }, a);
-            return true;
-        }
-    }
-
+    
     debug.log("navigate-back-to-bookmark: failed");
 
     return false;


### PR DESCRIPTION
@jlewallen please take a good look on this change.

https://code.conservify.org/jira/browse/FK-3902

Removing the if condition fixed the issue and it did not break anything in the Calibration proccess, and this flow is the only one which is using navigateBackToBookmark function. However I am not entierely sure of the purpose of this function, so please let me know if I'm missing anything

If also remove one of the for loops since it was basically the same.